### PR TITLE
[Feat] Helper 화면 내 지도 삽입 #9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,4 +76,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
 
+    // Map
+    implementation(libs.google.maps)
+    implementation(libs.maps.compose)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,9 @@
             </intent-filter>
         </activity>
 
-
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyCzu3LfhvJgyFXktsLl84itvLOypSv-Ii8"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
@@ -1,16 +1,15 @@
 package com.ganaljigi.kubf.ui.helper.component.information
 
-import android.graphics.drawable.Icon
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.snapping.SnapPosition.Center.position
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -18,30 +17,42 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Email
-import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.Phone
-import androidx.compose.material3.Icon
-import androidx.compose.material3.SegmentedButtonDefaults.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ganalijigi.kubf.R
-import com.ganaljigi.kubf.ui.helper.component.shortcut.ShortCutTitle
 import com.ganaljigi.kubf.ui.theme.Gray1
 import com.ganaljigi.kubf.ui.theme.Gray4
-import com.ganaljigi.kubf.ui.theme.MainGreen
 import com.ganaljigi.kubf.ui.theme.KUBFAndroidTheme
 import com.ganaljigi.kubf.ui.theme.MainGreen
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Marker
+import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.ui.unit.dp
+import com.google.android.gms.maps.model.*
+import com.google.android.gms.maps.CameraUpdateFactory
+import kotlinx.coroutines.launch
+import com.google.android.gms.maps.model.*
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.MapType
 
 //정보 제목 박스
 @Composable
@@ -125,8 +136,14 @@ fun InfoItemBox(
 fun MapBox(
     modifier: Modifier= Modifier
 ) {
+    val latLng = LatLng(37.54210, 127.0783)
+    val latLngState = MarkerState(position = latLng)
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(latLng, 10f)
+    }
+
     Box(
-        modifier=modifier
+        modifier = modifier
             //.size(width = 304.dp, height = 164.98.dp)
             .fillMaxWidth()
             .padding(horizontal = 12.dp)
@@ -136,10 +153,17 @@ fun MapBox(
                 width = 1.dp,
                 color = Gray1,
                 shape = RoundedCornerShape(10.dp)
-
             )
     ) {
-
+        GoogleMap (
+            modifier = Modifier.fillMaxSize(),
+            cameraPositionState = cameraPositionState,
+        ) {
+            Marker(
+                state = latLngState,
+                title = "장애학생지원센터"
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
@@ -139,7 +139,7 @@ fun MapBox(
     val latLng = LatLng(37.54210, 127.0783)
     val latLngState = MarkerState(position = latLng)
     val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(latLng, 10f)
+        position = CameraPosition.fromLatLngZoom(latLng, 17f)
     }
 
     Box(

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
@@ -39,8 +39,9 @@ import com.ganalijigi.kubf.R
 import com.ganaljigi.kubf.ui.helper.component.shortcut.ShortCutTitle
 import com.ganaljigi.kubf.ui.theme.Gray1
 import com.ganaljigi.kubf.ui.theme.Gray4
-import com.ganaljigi.kubf.ui.theme.Green
+import com.ganaljigi.kubf.ui.theme.MainGreen
 import com.ganaljigi.kubf.ui.theme.KUBFAndroidTheme
+import com.ganaljigi.kubf.ui.theme.MainGreen
 
 //정보 제목 박스
 @Composable
@@ -180,7 +181,7 @@ fun InfoBox(
                     text = "장애학생 지원센터: 105호\n장애학생 휴게실: 105-1호",
                     style = KUBFAndroidTheme.typography.regular14.copy(
                         fontSize = 14.sp,
-                        color = Green,
+                        color = MainGreen,
                         lineHeight = 20.sp
                     )
                 )

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/shortcut/ShortCutComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/shortcut/ShortCutComponent.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.ganaljigi.kubf.ui.theme.Green
+import com.ganaljigi.kubf.ui.theme.MainGreen
 import com.ganaljigi.kubf.ui.theme.KUBFAndroidTheme
 import com.ganaljigi.kubf.ui.theme.KUBFTypography
 
@@ -95,7 +95,7 @@ fun ShortCutItem(
 
             Text(
                 text = text,
-                color = Green,
+                color = MainGreen,
                 style = KUBFAndroidTheme.typography.medium14.copy(
                     fontSize = 14.sp
                 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ hilt = "2.52"
 hiltNavigationCompose = "1.2.0"
 hiltManager = "1.2.0"
 kotlinxSerializationJson = "1.8.0"
+google-maps = "18.0.2"
+maps-compose = "2.11.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,6 +43,8 @@ hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 hilt-manager = {group = "androidx.hilt" , name = "hilt-compiler", version.ref = "hiltManager"}
+google-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "google-maps" }
+maps-compose = { group = "com.google.maps.android", name = "maps-compose", version.ref = "maps-compose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 🚀 이슈번호

## ✏️ 변경사항
- HelperScreen의 정보 박스 내 장애학생지원센터의 위치를 표시한 구글 지도 삽입


## 📷 스크린샷
https://github.com/user-attachments/assets/40523fbf-a937-4a7e-b826-7ba5017aa9be


## ✍️ 사용법


## 🎸 기타
- 지도 확대, 축소 및 움직이기 외의 기능 추가 없음