### PR TITLE
[Fix] Roominfo viewmodel #31

### DIFF
--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/screen/HelperScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/screen/HelperScreen.kt
@@ -88,10 +88,11 @@ fun HelperScreen(
                 }
                 else -> {
                     state.notices.forEachIndexed { index, n ->
+                        val numberToShow = state.notices.size-index
                         NoticeItem(
                             title = n.title,
                             date = n.date,
-                            number = n.displayNumber,
+                            number = numberToShow,
                             index = index,
                             onClick = { uriHandler.openUri(n.url) }
                         )

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/screen/HelperScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/screen/HelperScreen.kt
@@ -32,11 +32,14 @@ import com.ganaljigi.kubf.ui.helper.component.shortcut.ShortCutItem
 import com.ganaljigi.kubf.ui.helper.component.shortcut.ShortCutTitle
 import com.ganaljigi.kubf.ui.helper.component.topappbar.HelperTopAppBar
 import com.ganaljigi.kubf.ui.helper.viewmodel.HelperViewModel
-import com.ganaljigi.kubf.ui.helper.viewmodel.Notice
 
 @Composable
 fun HelperScreen(
     onBackClick: () -> Unit,
+    navigateToNotice: () -> Unit = {},
+    navigateToDisableStudentHelper: () -> Unit = {},
+    navigateToSupport: () -> Unit = {},
+    navigateToJobInformation: () -> Unit = {},
     vm: HelperViewModel = hiltViewModel()
 ) {
     val state by vm.uiState.collectAsStateWithLifecycle()
@@ -53,7 +56,7 @@ fun HelperScreen(
         ) {
             //공지사항
 
-            NoticeTitle {}
+            NoticeTitle(onNavigateClick = navigateToNotice)
 //            NoticeItem(
 //                title = "[KIRD] 포용성장사업_이공계 장애 대학(원)생 경력개발 멘토링 모집 홍보 새글",
 //                date = "2025.05.13",
@@ -88,7 +91,7 @@ fun HelperScreen(
                         NoticeItem(
                             title = n.title,
                             date = n.date,
-                            number = state.notices.size - index,
+                            number = n.displayNumber,
                             index = index,
                             onClick = { uriHandler.openUri(n.url) }
                         )
@@ -107,17 +110,17 @@ fun HelperScreen(
                 ShortCutItem(
                     text = "장애학생 도우미",
                     iconResId = R.drawable.ic_helper_disablestudenthelper,
-                    onClick = {}
+                    onClick = navigateToDisableStudentHelper
                 )
                 ShortCutItem(
                     text = "지원 업무",
                     iconResId = R.drawable.ic_helper_support,
-                    onClick = {}
+                    onClick = navigateToSupport
                 )
                 ShortCutItem(
                     text = "채용 정보",
                     iconResId = R.drawable.ic_helper_jobinformation,
-                    onClick = {}
+                    onClick = navigateToJobInformation
                 )
             }
 

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/RoomInfoScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/RoomInfoScreen.kt
@@ -6,13 +6,16 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -33,52 +36,57 @@ fun RoomInfoScreen(
 ) {
     val scrollState = rememberScrollState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.systemBars)
-            .verticalScroll(scrollState)
-    ) {
-        RoomInfoTopAppBar(
-            buildingName = uiState.buildingName,
-            onBackClick = onBackClick
-        )
+    Scaffold(
+        topBar = {
+            RoomInfoTopAppBar(
+                buildingName = uiState.buildingName,
+                onBackClick = onBackClick
+            )
+        },
+        containerColor = Color.White
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+        ) {
+            RoomPic(roomPicUrls = uiState.roomPicUrls)
 
-        RoomPic(roomPicUrls = uiState.roomPicUrls)
+            RoomInfoDefaultComponent(
+                roomNumber = uiState.roomNumber,
+                roomName = uiState.roomName,
+                lecture = uiState.lecture,
+                capacity = uiState.capacity,
+                area = uiState.area,
+                floorSpace = uiState.floorSpace,
+                roomType = uiState.roomType,
+                department = uiState.department,
+                departmentNumber = uiState.departmentNumber
+            )
 
-        RoomInfoDefaultComponent(
-            roomNumber = uiState.roomNumber,
-            roomName = uiState.roomName,
-            lecture = uiState.lecture,
-            capacity = uiState.capacity,
-            area = uiState.area,
-            floorSpace = uiState.floorSpace,
-            roomType = uiState.roomType,
-            department = uiState.department,
-            departmentNumber = uiState.departmentNumber
-        )
+            DeskAndChairComponent(
+                allInOne = uiState.allInOne,
+                cinemaSeat = uiState.cinemaSeat,
+                oneSeat = uiState.oneSeat,
+                twoSeat = uiState.twoSeat,
+                multiSeat = uiState.multiSeat,
+                panel = uiState.panel,
+                backOfChair = uiState.backOfChair,
+                wheelChair = uiState.wheelChair,
+                wheelchairTable = uiState.wheelchairTable,
+                computerTable = uiState.computerTable,
+                modifier = Modifier.fillMaxWidth()
+            )
 
-        DeskAndChairComponent(
-            allInOne = uiState.allInOne,
-            cinemaSeat = uiState.cinemaSeat,
-            oneSeat = uiState.oneSeat,
-            twoSeat = uiState.twoSeat,
-            multiSeat = uiState.multiSeat,
-            panel = uiState.panel,
-            backOfChair = uiState.backOfChair,
-            wheelChair = uiState.wheelChair,
-            wheelchairTable = uiState.wheelchairTable,
-            computerTable = uiState.computerTable,
-            modifier = Modifier.fillMaxWidth()
-        )
+            DoorComponent(
+                frontDoor = uiState.frontDoor,
+                backDoor = uiState.backDoor,
+                modifier = Modifier.fillMaxWidth()
+            )
 
-        DoorComponent(
-            frontDoor = uiState.frontDoor,
-            backDoor = uiState.backDoor,
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        Spacer(modifier = Modifier.height(30.dp))
+            Spacer(modifier = Modifier.height(30.dp))
+        }
     }
 }
 

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/RoomInfoScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/RoomInfoScreen.kt
@@ -1,9 +1,11 @@
 package com.ganaljigi.kubf.ui.roominfo
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -12,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ganaljigi.kubf.ui.roominfo.component.DeskAndChairComponent
@@ -74,6 +77,8 @@ fun RoomInfoScreen(
             backDoor = uiState.backDoor,
             modifier = Modifier.fillMaxWidth()
         )
+
+        Spacer(modifier = Modifier.height(30.dp))
     }
 }
 

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomInfoDefaultComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomInfoDefaultComponent.kt
@@ -1,38 +1,58 @@
 package com.ganaljigi.kubf.ui.roominfo.component
 
+import android.content.Intent
+import android.net.Uri
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
+import android.widget.TextView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.ganalijigi.kubf.R
 import com.ganaljigi.kubf.ui.theme.Gray3
 import com.ganaljigi.kubf.ui.theme.Gray4
 import com.ganaljigi.kubf.ui.theme.KUBFAndroidTheme
-import androidx.compose.material3.Icon
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.window.Popup
 import com.ganaljigi.kubf.ui.theme.MainGreen
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.em
-import androidx.compose.ui.window.PopupProperties
-import com.ganalijigi.kubf.R
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.util.TypedValue
+import android.widget.PopupMenu
+import androidx.core.content.res.ResourcesCompat
+import android.widget.Toast
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.ui.text.style.TextDecoration
 
 @Composable
 fun RoomInfoDefaultComponent(
@@ -182,7 +202,7 @@ fun RoomInfoDefaultComponent(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
-                    painter = painterResource(R.drawable.ic_roominfo_roomtypequestion),
+                    painter = painterResource(R.drawable.ic_roominfo_roomtype), //TODO
                     contentDescription = "호실 형태 설명",
                     tint = Gray4,
                     modifier = Modifier
@@ -283,28 +303,18 @@ fun RoomInfoDefaultComponent(
                     text = department,
                     style = KUBFAndroidTheme.typography.semiBold16,
                     color = Color.Black,
-                    modifier = Modifier.padding(bottom = 4.dp)
+                    //modifier = Modifier.padding(bottom = 4.dp)
                 )
             }
 
-            Row(
-                modifier = Modifier
-                    .align(Alignment.End)
-            ) {
-                Icon(
-                    painter = painterResource(id=R.drawable.ic_roominfo_departmentnumber),
-                    contentDescription = "관리 부서 전화번호",
-                    modifier = Modifier
-                        .size(20.dp),
-                    tint = Gray4
-                )
+            Spacer(Modifier.height(4.dp))
 
-                Text(
-                    text = departmentNumber,
-                    modifier = Modifier,
-                    style = KUBFAndroidTheme.typography.regular14,
-                    color = Gray4
-                )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                DepartmentPhoneRow(departmentNumber = departmentNumber)
             }
         }
     }
@@ -331,6 +341,89 @@ fun LectureChip(
         )
     }
 }
+
+@Composable
+fun DepartmentPhoneRow(
+    departmentNumber: String,
+    modifier: Modifier = Modifier
+) {
+    val ctx = LocalContext.current
+    var showMenu by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_roominfo_departmentnumber),
+            contentDescription = "관리 부서 전화번호",
+            modifier = Modifier.size(20.dp),
+            tint = Gray3
+        )
+
+        //Spacer(Modifier.width(6.dp))
+
+        Box {
+            Text(
+                text = departmentNumber,
+                style = KUBFAndroidTheme.typography.regular13,
+                color = Gray3,
+                textDecoration = TextDecoration.Underline,
+                modifier = Modifier
+                    .padding(vertical = 2.dp)
+                    .clickable { showMenu = true }
+            )
+
+            DropdownMenu (
+                expanded = showMenu,
+                onDismissRequest = { showMenu = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text("복사") },
+                    onClick = {
+                        copyToClipboard(ctx, departmentNumber)
+                        Toast.makeText(ctx, "전화번호가 복사되었습니다.", Toast.LENGTH_SHORT).show()
+                        showMenu = false
+                    }
+                )
+                DropdownMenuItem(
+                    text = { Text("전화하기") },
+                    onClick = {
+                        copyToClipboard(ctx, departmentNumber)
+
+                        val dial = normalizeForDial(departmentNumber)
+                        if (dial.isBlank()) {
+                            Toast.makeText(ctx, "유효한 전화번호가 없습니다.", Toast.LENGTH_SHORT).show()
+                        } else {
+                            val intent = Intent(Intent.ACTION_DIAL).apply {
+                                data = Uri.fromParts("tel", dial, null)
+                            }
+                            ctx.startActivity(intent)
+                        }
+                        showMenu = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+/** 숫자/앞자리 + 허용. 나머지 제거해서 다이얼러가 확실히 인식하도록. */ //지피띠니가 해줌ㅋ
+private fun normalizeForDial(raw: String): String {
+    val t = raw.trim()
+    val out = StringBuilder()
+    t.forEachIndexed { i, c ->
+        if (c.isDigit() || (i == 0 && c == '+')) out.append(c)
+    }
+    return out.toString()
+}
+
+private fun copyToClipboard(ctx: Context, text: String) {
+    val cm = ctx.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    cm.setPrimaryClip(ClipData.newPlainText("전화번호", text))
+}
+
+
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/TopAppBar.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/TopAppBar.kt
@@ -1,9 +1,12 @@
 package com.ganaljigi.kubf.ui.roominfo.component
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -31,6 +34,7 @@ fun RoomInfoTopAppBar(
     ) {
         Box(
             modifier = Modifier
+                .windowInsetsPadding(WindowInsets.statusBars)
                 .fillMaxWidth()
                 .height(48.dp)
         ) {


### PR DESCRIPTION
## 🚀 이슈번호

## ✏️ 변경사항
- #31 머지 당시 푸시 누락된 커밋을 develop에 보완 및 반영


## 📷 스크린샷
<video
  src="https://github.com/user-attachments/assets/6486ba67-f5cd-41cc-90cf-2e282c4d707e"
  controls
  style="max-width:100%; height:auto;">
</video>




## ✍️ 사용법



## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 학과 전화번호 행 추가: 아이콘·밑줄 표시, 탭 시 메뉴(복사/전화하기) 제공. 복사 토스트 및 다이얼러 실행 지원.
- Refactor
  - 룸 정보 화면을 Scaffold 기반으로 재구성: 상단 앱바를 탑바로 이동하고 내부 패딩 적용, 흰색 배경, 스크롤 유지 및 하단 여백 추가.
- Style/UI
  - 상단 앱바에 상태바 인셋 패딩 적용. 아이콘 교체 및 정렬·간격 미세 조정.
- Chores
  - 도움말 화면에 여러 내비게이션 콜백 추가(호출 방식 변경).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->