### PR TITLE
[Fix] Helper UI 수정 #34

### DIFF
--- a/app/src/main/java/com/ganaljigi/kubf/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/navigation/MainNavHost.kt
@@ -8,7 +8,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.ganaljigi.kubf.ui.buildinginfo.screen.BuildingInfoScreen
+import com.ganaljigi.kubf.ui.helper.screen.DisableStudentHelperScreen
 import com.ganaljigi.kubf.ui.helper.screen.HelperScreen
+import com.ganaljigi.kubf.ui.helper.screen.JobInformationScreen
+import com.ganaljigi.kubf.ui.helper.screen.SupportScreen
 import com.ganaljigi.kubf.ui.home.screen.HomeScreen
 import com.ganaljigi.kubf.ui.home.screen.HomeSearchScreen
 import com.ganaljigi.kubf.ui.home.viewmodel.HomeViewModel
@@ -65,6 +68,10 @@ fun MainNavHost(
 //                padding = padding,
 //                navigateToNotice = { navController.navigate(Routes.Notice) },
                 onBackClick = { navController.popBackStack() },
+                navigateToNotice = { navController.navigate(Routes.Notice) },
+                navigateToDisableStudentHelper = { navController.navigate(Routes.DisableStudentHelper) },
+                navigateToSupport = { navController.navigate(Routes.Support) },
+                navigateToJobInformation = { navController.navigate(Routes.JobInformation) }
             )
         }
 
@@ -93,5 +100,18 @@ fun MainNavHost(
                 onBackClick = { navController.popBackStack() }
             )
         }
+
+        composable<Routes.DisableStudentHelper> {
+            DisableStudentHelperScreen(onBackClick = { navController.popBackStack() })
+        }
+
+        composable<Routes.Support> {
+            SupportScreen(onBackClick = { navController.popBackStack() })
+        }
+
+        composable<Routes.JobInformation> {
+            JobInformationScreen(onBackClick = { navController.popBackStack() })
+        }
+
     }
 }

--- a/app/src/main/java/com/ganaljigi/kubf/navigation/Routes.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/navigation/Routes.kt
@@ -33,4 +33,8 @@ sealed interface Routes {
 
     @Serializable
     data object Support : Routes
+    @Serializable
+    data object DisableStudentHelper : Routes
+    @Serializable
+    data object JobInformation : Routes
 }

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
@@ -152,20 +152,31 @@ fun MapBox(
         position = CameraPosition.fromLatLngZoom(latLng, 17f)
     }
 
-    var uiSettings by remember { mutableStateOf(MapUiSettings()) }
+    var uiSettings by remember {
+        mutableStateOf(
+            MapUiSettings(
+                zoomGesturesEnabled = true,
+                zoomControlsEnabled = true,
+                scrollGesturesEnabled = false,
+                scrollGesturesEnabledDuringRotateOrZoom = false,
+                rotationGesturesEnabled = false,
+                tiltGesturesEnabled = false
+            )
+        )
+    }
     var properties by remember {
         mutableStateOf(MapProperties(mapType = MapType.NORMAL))
     }
 
     LaunchedEffect(Unit) {
-        uiSettings = uiSettings.copy(
-            zoomGesturesEnabled = true,
-            zoomControlsEnabled = true, // 우측 +/− 버튼 (싫으면 false)
-            scrollGesturesEnabled = false,
-            scrollGesturesEnabledDuringRotateOrZoom = false,
-            rotationGesturesEnabled = false,
-            tiltGesturesEnabled = false
-        )
+//        uiSettings = uiSettings.copy(
+//            zoomGesturesEnabled = true,
+//            zoomControlsEnabled = true, // 우측 +/− 버튼 (싫으면 false)
+//            scrollGesturesEnabled = false,
+//            scrollGesturesEnabledDuringRotateOrZoom = false,
+//            rotationGesturesEnabled = false,
+//            tiltGesturesEnabled = false
+//        )
 
     }
 

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
@@ -63,6 +63,7 @@ import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.MapType
 import android.net.Uri
+import androidx.compose.ui.graphics.Color
 
 //정보 제목 박스
 @Composable
@@ -218,7 +219,7 @@ fun InfoBox(
             .padding(horizontal = 16.dp)
             .wrapContentHeight()
             .clip(RoundedCornerShape(8.dp))
-            .background(color = Gray1)
+            .background(color = Color.White)
             .border(
                 color = Gray1,
                 shape = RoundedCornerShape(8.dp),

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
@@ -1,8 +1,14 @@
 package com.ganaljigi.kubf.ui.helper.component.information
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.snapping.SnapPosition.Center.position
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,6 +47,8 @@ import com.google.android.gms.maps.model.Marker
 import androidx.compose.runtime.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.model.*
 import com.google.android.gms.maps.CameraUpdateFactory
@@ -54,6 +62,7 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.MapType
+import android.net.Uri
 
 //정보 제목 박스
 @Composable
@@ -246,13 +255,17 @@ fun InfoBox(
         ) {
             Column {
                 Spacer(modifier = Modifier.height(1.5.dp))
-                Text(
-                    text = "02-450-3968",
-                    modifier = Modifier.height(20.dp),
-                    style = KUBFAndroidTheme.typography.regular14.copy(
-                        fontSize = 14.sp,
-                        lineHeight = 20.sp
-                    )
+//                Text(
+//                    text = "02-450-3968",
+//                    modifier = Modifier.height(20.dp),
+//                    style = KUBFAndroidTheme.typography.regular14.copy(
+//                        fontSize = 14.sp,
+//                        lineHeight = 20.sp
+//                    )
+//                )
+                PhoneActionText(
+                    number = "02-450-3968",
+                    modifier = Modifier.height(20.dp)
                 )
             }
         }
@@ -273,6 +286,70 @@ fun InfoBox(
             )
         }
         Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+private fun normalizeForDial(raw: String): String {
+    val t = raw.trim()
+    val out = StringBuilder()
+    t.forEachIndexed { i, c ->
+        if (c.isDigit() || (i == 0 && c == '+')) out.append(c)
+    }
+    return out.toString()
+}
+
+private fun copyToClipboard(ctx: Context, text: String) {
+    val cm = ctx.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    cm.setPrimaryClip(ClipData.newPlainText("전화번호", text))
+}
+
+@Composable
+private fun PhoneActionText(
+    number: String,
+    modifier: Modifier = Modifier,
+) {
+    val ctx = LocalContext.current
+    var showMenu by remember { mutableStateOf(false) }
+
+    Box(modifier) {
+        Text(
+            text = number,
+            style = KUBFAndroidTheme.typography.regular14,
+            textDecoration = TextDecoration.Underline,
+            modifier = Modifier
+                .padding(vertical = 2.dp)
+                .clickable { showMenu = true }
+        )
+
+        DropdownMenu(
+            expanded = showMenu,
+            onDismissRequest = { showMenu = false }
+        ) {
+            DropdownMenuItem(
+                text = { Text("복사") },
+                onClick = {
+                    copyToClipboard(ctx, number)
+                    Toast.makeText(ctx, "전화번호가 복사되었습니다.", Toast.LENGTH_SHORT).show()
+                    showMenu = false
+                }
+            )
+            DropdownMenuItem(
+                text = { Text("전화하기") },
+                onClick = {
+                    copyToClipboard(ctx, number)
+                    val dial = normalizeForDial(number)
+                    if (dial.isBlank()) {
+                        Toast.makeText(ctx, "유효한 전화번호가 없습니다.", Toast.LENGTH_SHORT).show()
+                    } else {
+                        val intent = Intent(Intent.ACTION_DIAL).apply {
+                            data = Uri.fromParts("tel", dial, null)
+                        }
+                        ctx.startActivity(intent)
+                    }
+                    showMenu = false
+                }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/information/InformationComponent.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.*
 import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.model.*
 import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.UiSettings
 import kotlinx.coroutines.launch
 import com.google.android.gms.maps.model.*
 import com.google.maps.android.compose.GoogleMap
@@ -145,6 +146,18 @@ fun MapBox(
     var uiSettings by remember { mutableStateOf(MapUiSettings()) }
     var properties by remember {
         mutableStateOf(MapProperties(mapType = MapType.NORMAL))
+    }
+
+    LaunchedEffect(Unit) {
+        uiSettings = uiSettings.copy(
+            zoomGesturesEnabled = true,
+            zoomControlsEnabled = true, // 우측 +/− 버튼 (싫으면 false)
+            scrollGesturesEnabled = false,
+            scrollGesturesEnabledDuringRotateOrZoom = false,
+            rotationGesturesEnabled = false,
+            tiltGesturesEnabled = false
+        )
+
     }
 
     Box(

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/notice/NoticeComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/notice/NoticeComponent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowRight
@@ -19,12 +20,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ganaljigi.kubf.ui.theme.Gray3
 import com.ganaljigi.kubf.ui.theme.KUBFAndroidTheme
 import java.sql.Date
+import com.ganalijigi.kubf.R
 
 //공지사항도 ID
 
@@ -51,10 +54,15 @@ fun NoticeTitle(
                 )
             )
 
-            IconButton(onClick = onNavigateClick) {
+            IconButton(
+                onClick = onNavigateClick,
+                modifier = Modifier
+                    .offset(x = (12).dp)
+            ) {
                 Icon(
-                    imageVector = Icons.Default.KeyboardArrowRight,
-                    contentDescription = "공지사항 페이지로 이동"
+                    painter = painterResource(id = R.drawable.ic_helper_arrowleft_gray),
+                    contentDescription = "공지사항 페이지로 이동",
+                    tint = Gray3
                 )
             }
         }

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/shortcut/ShortCutComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/shortcut/ShortCutComponent.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.unit.sp
 import com.ganaljigi.kubf.ui.theme.MainGreen
 import com.ganaljigi.kubf.ui.theme.KUBFAndroidTheme
 import com.ganaljigi.kubf.ui.theme.KUBFTypography
+import com.ganalijigi.kubf.R
+import com.ganaljigi.kubf.ui.theme.Gray2
 
 //바로가기 제목 박스
 @Composable
@@ -103,12 +105,12 @@ fun ShortCutItem(
             Spacer(modifier = Modifier.weight(1f))
 
             Icon(
-                imageVector = Icons.Default.KeyboardArrowRight,
+                painter = painterResource(id = R.drawable.ic_helper_arrowleft_lightgray),
                 contentDescription = "해당 바로가기 웹뷰 ㄱㄱ",
-                tint = Color.LightGray,
+                tint = Gray2,
                 modifier = Modifier
                     .padding(end = 16.dp)
-                    .size(20.dp)
+                    .size(24.dp)
             )
         }
     }

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/shortcut/ShortCutComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/shortcut/ShortCutComponent.kt
@@ -2,6 +2,7 @@ package com.ganaljigi.kubf.ui.helper.component.shortcut
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -20,6 +21,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -30,6 +33,7 @@ import com.ganaljigi.kubf.ui.theme.MainGreen
 import com.ganaljigi.kubf.ui.theme.KUBFAndroidTheme
 import com.ganaljigi.kubf.ui.theme.KUBFTypography
 import com.ganalijigi.kubf.R
+import com.ganaljigi.kubf.ui.theme.Gray1
 import com.ganaljigi.kubf.ui.theme.Gray2
 
 //바로가기 제목 박스
@@ -51,7 +55,6 @@ fun ShortCutTitle() {
     }
 }
 
-//바로가기 작은 박스
 @Composable
 fun ShortCutItem(
     modifier: Modifier = Modifier,
@@ -59,62 +62,75 @@ fun ShortCutItem(
     iconResId: Int? = null,
     onClick: () -> Unit
 ) {
-    Surface(
+    val shape = RoundedCornerShape(8.dp)
+
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp)
-            .height(48.dp),
-        shape = RoundedCornerShape(8.dp),
-        color = Color.White,
-        shadowElevation = 2.dp,
-        border = BorderStroke(1.dp, Color(0xFFEEEEEE)),
-        onClick = onClick
+            .shadow(
+                elevation = 6.dp,           // ← blur 느낌. 필요하면 4~8dp 사이에서 조절
+                shape = shape,
+                ambientColor = Color(0x1A000000),
+                spotColor = Color(0x1A000000)
+            )
+            .clip(shape)
     ) {
-        Row(
+        Surface(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(start = 16.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .fillMaxWidth()
+                .height(48.dp),
+            shape = shape,
+            color = Color.White,
+            border = BorderStroke(1.dp, Gray1),
+            shadowElevation = 0.dp,
+            tonalElevation = 0.dp,
+            onClick = onClick
         ) {
-            // 아이콘이 null이면 기본 아이콘 또는 빈 박스 대체
-            if (iconResId != null) {
-                Image(
-                    painter = painterResource(id = iconResId),
-                    contentDescription = "바로가기 아이콘",
-                    modifier = Modifier.size(20.dp)
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(start = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (iconResId != null) {
+                    Image(
+                        painter = painterResource(id = iconResId),
+                        contentDescription = "바로가기 아이콘",
+                        modifier = Modifier.size(20.dp)
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.KeyboardArrowRight,
+                        contentDescription = "기본 아이콘",
+                        modifier = Modifier.size(20.dp),
+                        tint = Color.Gray
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                Text(
+                    text = text,
+                    color = MainGreen,
+                    style = KUBFAndroidTheme.typography.medium14.copy(fontSize = 14.sp)
                 )
-            } else {
-                // 기본 아이콘으로 대체 (예시: search 아이콘)
+
+                Spacer(modifier = Modifier.weight(1f))
+
                 Icon(
-                    imageVector = Icons.Default.KeyboardArrowRight, // 또는 Search 등
-                    contentDescription = "기본 아이콘",
-                    modifier = Modifier.size(20.dp),
-                    tint = Color.Gray
+                    painter = painterResource(id = R.drawable.ic_helper_arrowleft_lightgray),
+                    contentDescription = "해당 바로가기 웹뷰 ㄱㄱ",
+                    tint = Gray2,
+                    modifier = Modifier
+                        .padding(end = 16.dp)
+                        .size(24.dp)
                 )
             }
-
-            Spacer(modifier = Modifier.width(8.dp))
-
-            Text(
-                text = text,
-                color = MainGreen,
-                style = KUBFAndroidTheme.typography.medium14.copy(
-                    fontSize = 14.sp
-                )
-            )
-            Spacer(modifier = Modifier.weight(1f))
-
-            Icon(
-                painter = painterResource(id = R.drawable.ic_helper_arrowleft_lightgray),
-                contentDescription = "해당 바로가기 웹뷰 ㄱㄱ",
-                tint = Gray2,
-                modifier = Modifier
-                    .padding(end = 16.dp)
-                    .size(24.dp)
-            )
         }
     }
 }
+
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/topappbar/TopAppBarComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/component/topappbar/TopAppBarComponent.kt
@@ -21,11 +21,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ganaljigi.kubf.ui.theme.KUBFAndroidTheme
+import com.ganalijigi.kubf.R
 
 //장애학생지원센터 TopAppBar
 @OptIn(ExperimentalMaterial3Api::class)
@@ -53,7 +55,7 @@ fun HelperTopAppBar(
                 modifier = Modifier.fillMaxHeight()
             ) {
                 Icon(
-                    imageVector = Icons.Default.KeyboardArrowLeft,
+                    painter = painterResource(id = R.drawable.ic_helper_arrowleft_black),
                     contentDescription = "뒤로가기",
                     modifier = Modifier.size(24.dp)
                 )

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/mapper/HelperMapper.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/mapper/HelperMapper.kt
@@ -30,5 +30,7 @@ fun HelperNoticeResponseDto.toUiState(): HelperUiState {
 fun HelperNoticeDto.toUi(): NoticeUi = NoticeUi(
     title = title,
     date = date,
-    url = url
+    url = url,
+    rawNumber = number,
+    displayNumber = number
 )

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/response/HelperResponseDto.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/response/HelperResponseDto.kt
@@ -24,5 +24,7 @@ data class HelperNoticeDto(
     @SerialName("date")
     val date: String,
     @SerialName("url")
-    val url: String
+    val url: String,
+    @SerialName("number")
+    val number: Int
 )

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/screen/HelperScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/screen/HelperScreen.kt
@@ -88,11 +88,10 @@ fun HelperScreen(
                 }
                 else -> {
                     state.notices.forEachIndexed { index, n ->
-                        val numberToShow = state.notices.size-index
                         NoticeItem(
                             title = n.title,
                             date = n.date,
-                            number = numberToShow,
+                            number = n.displayNumber,
                             index = index,
                             onClick = { uriHandler.openUri(n.url) }
                         )

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/screen/SupportScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/screen/SupportScreen.kt
@@ -66,7 +66,7 @@ fun SupportScreen(
                     onClick = { tabIndex = index },
                     text = {
                         Text(
-                            text = "교수/학습",
+                            text = title,
                             style = KUBFAndroidTheme.typography.medium14
                         )
                     }

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/viewmodel/HelperUiState.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/viewmodel/HelperUiState.kt
@@ -9,5 +9,7 @@ data class HelperUiState(
 data class NoticeUi(
     val title: String,
     val date: String,
-    val url: String
+    val url: String,
+    val rawNumber: Int? = null,
+    val displayNumber: Int = 0
 )

--- a/app/src/main/java/com/ganaljigi/kubf/ui/helper/viewmodel/HelperViewModel.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/helper/viewmodel/HelperViewModel.kt
@@ -37,14 +37,17 @@ class HelperViewModel @Inject constructor(
     private fun String.toLocalDateOrMin(): LocalDate =
         runCatching { LocalDate.parse(this, dateFmt) }.getOrElse { LocalDate.MIN }
 
-    fun loadNotices(
-
-    ) {
+    fun loadNotices() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             repository.fetchNotices().fold(
                 onSuccess = { dto ->
                     val mapped = dto.toUiState()
+
+                    val dateFmt = DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.KOREA)
+                    fun String.toLocalDateOrMin() =
+                        runCatching { LocalDate.parse(this, dateFmt) }.getOrElse { LocalDate.MIN }
+
                     val top3 = mapped.notices
                         .sortedByDescending { it.date.toLocalDateOrMin() }
                         .take(3)
@@ -55,10 +58,12 @@ class HelperViewModel @Inject constructor(
                     )
                 },
                 onFailure = { e ->
-                     _uiState.update { it.copy(isLoading = false, error = e.message ?: "") }
+                    _uiState.update { it.copy(isLoading = false, error = e.message ?: "") }
                 }
             )
         }
     }
+
+
     fun retry() = loadNotices()
 }

--- a/app/src/main/res/drawable/ic_helper_arrowleft_black.xml
+++ b/app/src/main/res/drawable/ic_helper_arrowleft_black.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M15.582,20.369C15.875,20.076 15.875,19.601 15.582,19.308L8.121,11.848L15.48,4.49C15.773,4.197 15.772,3.722 15.48,3.429C15.187,3.136 14.712,3.136 14.419,3.429L6.53,11.318C6.237,11.611 6.237,12.085 6.53,12.378C6.549,12.396 6.567,12.413 6.587,12.429C6.601,12.446 6.616,12.464 6.632,12.48L14.521,20.369C14.814,20.662 15.289,20.662 15.582,20.369Z"
+        android:fillColor="#212121"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_helper_arrowleft_gray.xml
+++ b/app/src/main/res/drawable/ic_helper_arrowleft_gray.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M8.419,20.369C8.126,20.076 8.126,19.601 8.419,19.308L15.879,11.848L8.521,4.49C8.228,4.197 8.228,3.722 8.521,3.429C8.814,3.136 9.289,3.136 9.582,3.429L17.47,11.318C17.763,11.611 17.763,12.085 17.47,12.378C17.452,12.396 17.433,12.413 17.414,12.429C17.399,12.446 17.385,12.464 17.369,12.48L9.48,20.369C9.187,20.662 8.712,20.662 8.419,20.369Z"
+        android:fillColor="#999999"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_helper_arrowleft_lightgray.xml
+++ b/app/src/main/res/drawable/ic_helper_arrowleft_lightgray.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M8.419,20.369C8.126,20.076 8.126,19.601 8.419,19.308L15.879,11.848L8.521,4.49C8.228,4.197 8.228,3.722 8.521,3.429C8.814,3.136 9.289,3.136 9.582,3.429L17.47,11.318C17.763,11.611 17.763,12.085 17.47,12.378C17.452,12.396 17.433,12.413 17.414,12.429C17.399,12.446 17.385,12.464 17.369,12.48L9.48,20.369C9.187,20.662 8.712,20.662 8.419,20.369Z"
+        android:fillColor="#D7D7D7"/>
+  </group>
+</vector>


### PR DESCRIPTION
## 🚀 이슈번호

## ✏️ 변경사항
- HelperScreen에 삽입된 장애학생지원센터 구글맵 확대/축소 기능만 남김
- 장애학생지원센터 전화번호 복사/전화 바로가기 기능 추가
- HelperScreen내 네비게이션 추가
- 공지사항 번호 순서 수정


## 📷 스크린샷
<video
  src="https://github.com/user-attachments/assets/dd9e9eaa-f61b-4660-9e03-f37f4eac31ec"
  controls
  style="max-width:100%; height:auto;">
</video>


## ✍️ 사용법



## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 장애학생 도우미, 취업정보, 지원 화면을 앱 네비게이션에 추가.
  * 전화번호 텍스트에서 복사 및 통화 동작(클립보드 복사, 다이얼 실행) 제공.

* **개선**
  * 공지 목록 번호 표기를 displayNumber로 일원화.
  * 지원 화면 탭 라벨을 동적 타이틀로 변경.
  * 일부 UI(아이콘/단축키/탑바 등) 시각 및 레이아웃 조정, 지도 사용성 설정 업데이트.

* **데이터**
  * 공지 응답에 number 필드 추가 및 UI 상태에 rawNumber/displayNumber 확장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->