### PR TITLE
[Fix] roominfo 수정 #44

### DIFF
--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/RoomInfoScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/RoomInfoScreen.kt
@@ -36,6 +36,9 @@ fun RoomInfoScreen(
 ) {
     val scrollState = rememberScrollState()
 
+    val showDeskAndChair = uiState.hasRoomInfo
+    val showDoor = uiState.hasRoomInfo
+
     Scaffold(
         topBar = {
             RoomInfoTopAppBar(
@@ -65,25 +68,29 @@ fun RoomInfoScreen(
                 departmentNumber = uiState.departmentNumber
             )
 
-            DeskAndChairComponent(
-                allInOne = uiState.allInOne,
-                cinemaSeat = uiState.cinemaSeat,
-                oneSeat = uiState.oneSeat,
-                twoSeat = uiState.twoSeat,
-                multiSeat = uiState.multiSeat,
-                panel = uiState.panel,
-                backOfChair = uiState.backOfChair,
-                wheelChair = uiState.wheelChair,
-                wheelchairTable = uiState.wheelchairTable,
-                computerTable = uiState.computerTable,
-                modifier = Modifier.fillMaxWidth()
-            )
+            if (showDeskAndChair) {
+                DeskAndChairComponent(
+                    allInOne = uiState.allInOne,
+                    cinemaSeat = uiState.cinemaSeat,
+                    oneSeat = uiState.oneSeat,
+                    twoSeat = uiState.twoSeat,
+                    multiSeat = uiState.multiSeat,
+                    panel = uiState.panel,
+                    backOfChair = uiState.backOfChair,
+                    wheelChair = uiState.wheelChair,
+                    wheelchairTable = uiState.wheelchairTable,
+                    computerTable = uiState.computerTable,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
 
-            DoorComponent(
-                frontDoor = uiState.frontDoor,
-                backDoor = uiState.backDoor,
-                modifier = Modifier.fillMaxWidth()
-            )
+            if (showDoor) {
+                DoorComponent(
+                    frontDoor = uiState.frontDoor,
+                    backDoor = uiState.backDoor,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
 
             Spacer(modifier = Modifier.height(30.dp))
         }

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/RoomInfoScreen.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/RoomInfoScreen.kt
@@ -62,6 +62,7 @@ fun RoomInfoScreen(
                 lecture = uiState.lecture,
                 capacity = uiState.capacity,
                 area = uiState.area,
+                roomComment = uiState.roomComment,
                 floorSpace = uiState.floorSpace,
                 roomType = uiState.roomType,
                 department = uiState.department,

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomInfoDefaultComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomInfoDefaultComponent.kt
@@ -50,8 +50,10 @@ import android.util.TypedValue
 import android.widget.PopupMenu
 import androidx.core.content.res.ResourcesCompat
 import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Surface
 import androidx.compose.ui.text.style.TextDecoration
 
 @Composable
@@ -250,19 +252,39 @@ fun RoomInfoDefaultComponent(
                     properties = PopupProperties(focusable = true),
                     onDismissRequest = { showTooltip = false }
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .size(width = 248.dp, height = 82.dp)
-                            .shadow(elevation = 4.dp, shape = RoundedCornerShape(8.dp))
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(Color.White)
-                            .padding(12.dp),
-                        contentAlignment = Alignment.CenterStart
+//                    Box(
+//                        modifier = Modifier
+//                            .size(width = 248.dp, height = 82.dp)
+//                            .shadow(elevation = 4.dp, shape = RoundedCornerShape(8.dp))
+//                            .clip(RoundedCornerShape(8.dp))
+//                            .background(Color.White)
+//                            .padding(12.dp),
+//                        contentAlignment = Alignment.CenterStart
+//                    ) {
+//                        Text(
+//                            text = buildAnnotatedString {
+//                                withStyle(SpanStyle(color = MainGreen)) { append("평탄식") }
+//                                append("은 바닥이 전부 평평한 호실, \n")
+//                                withStyle(SpanStyle(color = MainGreen)) { append("계단식") }
+//                                append("은 바닥에 단차가 있는 호실입니다.")
+//                            },
+//                            style = KUBFAndroidTheme.typography.regular14.copy(
+//                                lineHeight = 25.sp,
+//                                letterSpacing = (-0.025).em
+//                            )
+//                        )
+//                    }
+                    Surface(
+                        shape = RoundedCornerShape(20.dp),
+                        color = Color.White.copy(alpha = 0.9f),
+                        border = BorderStroke(1.dp, Color.White),
+                        shadowElevation = 4.dp
                     ) {
                         Text(
+                            modifier = Modifier.padding(16.dp),
                             text = buildAnnotatedString {
                                 withStyle(SpanStyle(color = MainGreen)) { append("평탄식") }
-                                append("은 바닥이 전부 평평한 호실, \n")
+                                append("은 바닥이 전부 평평한 호실,\n")
                                 withStyle(SpanStyle(color = MainGreen)) { append("계단식") }
                                 append("은 바닥에 단차가 있는 호실입니다.")
                             },

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomInfoDefaultComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomInfoDefaultComponent.kt
@@ -63,6 +63,7 @@ fun RoomInfoDefaultComponent(
     lecture: Boolean,
     capacity: Int,
     area: Double,
+    roomComment: String?,
     floorSpace: Double,
     roomType: String,
     department: String,
@@ -185,6 +186,43 @@ fun RoomInfoDefaultComponent(
                     style = KUBFAndroidTheme.typography.regular14,
                     color = Color.Black
                 )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // 특이사항
+        val commentText = roomComment?.takeUnless { it.isBlank() } ?: "-"
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_roominfo_roomcomment),
+                contentDescription = "특이사항",
+                tint = Gray4,
+                modifier = Modifier
+                    .size(20.dp)
+            )
+
+            Spacer(Modifier.width(8.dp))
+
+            Text(
+                text = "특이사항",
+                style = KUBFAndroidTheme.typography.regular14,
+                color = Gray4
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Row(
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                Text(
+                    text = commentText,
+                    style = KUBFAndroidTheme.typography.semiBold16,
+                    color = Color.Black
+                )
+
             }
         }
 
@@ -457,6 +495,7 @@ fun RoomInfoDefaultComponentPreview() {
             lecture = true,
             capacity = 34,
             area = 60.6,
+            roomComment = "",
             floorSpace = 18.3,
             roomType = "평탄식",
             department = "정보인프라팀",

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomInfoDefaultComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomInfoDefaultComponent.kt
@@ -55,7 +55,9 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Surface
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun RoomInfoDefaultComponent(
     roomNumber: String,
@@ -75,9 +77,10 @@ fun RoomInfoDefaultComponent(
             .padding(horizontal = 16.dp, vertical = 16.dp)
     ) {
         // 상단 제목 + 강의실 칩
-        Row(
+        FlowRow (
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text(
                 text = "$roomNumber ${roomName ?: ""}",
@@ -85,9 +88,12 @@ fun RoomInfoDefaultComponent(
                     fontWeight = FontWeight.Bold,
                     fontSize = 18.sp
                 ),
-                color = Color.Black
+                color = Color.Black,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
-            Spacer(modifier = Modifier.width(8.dp))
+
+            //Spacer(modifier = Modifier.width(8.dp))
             if (lecture) {
                 LectureChip()
             }

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomPicComponent.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/component/RoomPicComponent.kt
@@ -1,26 +1,38 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 package com.ganaljigi.kubf.ui.roominfo.component
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import coil3.compose.AsyncImage
 import com.ganaljigi.kubf.ui.theme.KUBFAndroidTheme
+import com.ganalijigi.kubf.R
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.zIndex
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -29,57 +41,232 @@ fun RoomPic(
     modifier: Modifier = Modifier
 ) {
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { roomPicUrls.size })
+    var showViewer by remember { mutableStateOf(false) }
 
     Box(modifier = modifier.fillMaxWidth()) {
         HorizontalPager(
             state = pagerState,
             modifier = Modifier
                 .fillMaxWidth()
+                .clickable(enabled = roomPicUrls.isNotEmpty()) { showViewer = true }
         ) { page ->
             AsyncImage(
                 model = roomPicUrls[page],
                 contentDescription = "강의실 사진",
                 contentScale = ContentScale.FillWidth,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    //.height(200.dp)
+                modifier = Modifier.fillMaxWidth()
             )
         }
-        //TODO: 패딩 조정
+
         if (roomPicUrls.size > 1) {
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 12.dp)
-                    .background(Color(0xFF212121)
-                        .copy(alpha = 0.6f),
+                    .background(
+                        Color(0xFF212121).copy(alpha = 0.6f),
                         shape = RoundedCornerShape(20.dp)
-                        )
+                    )
+                    .zIndex(2f)
             ) {
-                Row(
+//                Row(
+//                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+//                    verticalAlignment = Alignment.CenterVertically
+//                ) {
+//                    Text(
+//                        text = "${pagerState.currentPage + 1}",
+//                        style = KUBFAndroidTheme.typography.semiBold13.copy(color = Color.White)
+//                    )
+//                    Spacer(modifier = Modifier.width(1.5.dp))
+//                    Text(
+//                        text = "/",
+//                        style = KUBFAndroidTheme.typography.regular13.copy(color = Color.White)
+//                    )
+//                    Spacer(modifier = Modifier.width(1.5.dp))
+//                    Text(
+//                        text = "${roomPicUrls.size}",
+//                        style = KUBFAndroidTheme.typography.regular13.copy(color = Color.White)
+//                    )
+//                }
+                PagerCounter(pagerState = pagerState, total = roomPicUrls.size)
+            }
+        }
+    }
+
+    if (showViewer) {
+        Dialog(
+            onDismissRequest = { showViewer = false },
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            val insetPadding = WindowInsets.systemBars.asPaddingValues()
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.6f))
+            ) {
+                val viewPager = rememberPagerState(
+                    initialPage = pagerState.currentPage,
+                    pageCount = { roomPicUrls.size }
+                )
+
+                //확대 하는 중에는 페이지 넘김 안됨
+                var canSwipe by remember { mutableStateOf(true) }
+
+                HorizontalPager(
+                    state = viewPager,
+                    modifier = Modifier.fillMaxSize(),
+                    userScrollEnabled = canSwipe
+                ) { page ->
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        ZoomableImage(
+                            url = roomPicUrls[page],
+                            modifier = Modifier
+                                .fillMaxSize(),
+                            onBaseScale = { atBase -> canSwipe = atBase }
+                        )
+
+                        if (roomPicUrls.size > 1) {
+                            Box(
+                                modifier = Modifier
+                                    .align(Alignment.BottomCenter)
+                                    .padding(
+                                        bottom = insetPadding.calculateBottomPadding() + 12.dp
+                                    )
+                                    .background(
+                                        Color(0xFF212121).copy(alpha = 0.6f),
+                                        shape = RoundedCornerShape(20.dp)
+                                    )
+                                    .zIndex(3f)
+                            ) {
+                                PagerCounter(pagerState = viewPager, total = roomPicUrls.size)
+                            }
+                        }
+                    }
+                }
+
+                IconButton(
+                    onClick = { showViewer = false },
                     modifier = Modifier
-                        .padding(horizontal = 8.dp, vertical = 2.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                        .align(Alignment.TopEnd)
+                        .padding(
+                            top = insetPadding.calculateTopPadding() + 12.dp,
+                            end = 16.dp
+                        )
+                        .size(24.dp)
+                        .zIndex(1f)
                 ) {
-                    Text(
-                        text = "${pagerState.currentPage + 1}",
-                        style = KUBFAndroidTheme.typography.semiBold13.copy(color = Color.White)
-                    )
-                    Spacer(modifier = Modifier.width(1.5.dp))
-                    Text(
-                        text = "/",
-                        style = KUBFAndroidTheme.typography.regular13.copy(color = Color.White)
-                    )
-                    Spacer(modifier = Modifier.width(1.5.dp))
-                    Text(
-                        text = "${roomPicUrls.size}",
-                        style = KUBFAndroidTheme.typography.regular13.copy(color = Color.White)
+                    Icon(
+                        painter = painterResource(R.drawable.ic_roominfo_picviewer),
+                        contentDescription = "닫기",
+                        tint = Color.White
                     )
                 }
             }
         }
     }
 }
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ZoomableImage(
+    url: String,
+    modifier: Modifier = Modifier,
+    onBaseScale: (Boolean) -> Unit = {}
+) {
+    var scale by remember { mutableStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+
+    LaunchedEffect(Unit) {
+        onBaseScale(true)
+    }
+
+    val transformState = rememberTransformableState { zoomChange, panChange, _ ->
+        val newScale = (scale * zoomChange).coerceIn(1f, 4f)
+        scale = newScale
+        if (newScale > 1f) {
+            offset += panChange
+            onBaseScale(false)
+        } else {
+            offset = Offset.Zero
+            onBaseScale(true)
+        }
+    }
+
+    val doubleTapReset = Modifier.pointerInput(Unit) {
+        detectTapGestures(
+            onDoubleTap = {
+                scale = 1f
+                offset = Offset.Zero
+                onBaseScale(true)
+            }
+        )
+    }
+
+    val zoomModifier =
+        if (scale > 1f) {
+            Modifier.transformable(
+                state = transformState,
+                canPan = { true }
+            )
+        } else {
+            Modifier
+        }
+
+    AsyncImage(
+        model = url,
+        contentDescription = "이미지 확대",
+        contentScale = ContentScale.Fit,
+        modifier = modifier
+            .graphicsLayer {
+                translationX = offset.x
+                translationY = offset.y
+                scaleX = scale
+                scaleY = scale
+            }
+            .then(zoomModifier)
+            .then(doubleTapReset)
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun PagerCounter(
+    pagerState: androidx.compose.foundation.pager.PagerState,
+    total: Int,
+    modifier: Modifier = Modifier
+) {
+    val current by remember(pagerState) { derivedStateOf { pagerState.currentPage } }
+
+    Box(
+        modifier = modifier
+            .background(Color(0xFF212121).copy(alpha = 0.6f), RoundedCornerShape(20.dp))
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "${current + 1}",
+                style = KUBFAndroidTheme.typography.semiBold13.copy(color = Color.White)
+            )
+            Spacer(modifier = Modifier.width(1.5.dp))
+            Text(
+                text = "/",
+                style = KUBFAndroidTheme.typography.regular13.copy(color = Color.White)
+            )
+            Spacer(modifier = Modifier.width(1.5.dp))
+            Text(
+                text = "$total",
+                style = KUBFAndroidTheme.typography.regular13.copy(color = Color.White)
+            )
+        }
+    }
+}
+
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/mapper/RoomInfoMapper.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/mapper/RoomInfoMapper.kt
@@ -32,7 +32,10 @@ fun RoomInfoResponseDto.toUiState(): RoomInfoUiState {
         departmentNumber = r.departmentNumber,
 
         //이미지(ROOM만 쓸거임)
-        roomPicUrls = r.images.filter { it.imageType == "ROOM" }.map { it.imageUrl },
+        roomPicUrls = r.images
+            .sortedBy { it.imageType != "ROOM" }
+            .map { it.imageUrl }
+            .distinct(),
 
         // roomInfo가 null이면 전부 false로 (이렇게 하는게 좋다고 지피띠니가 말해줌
         allInOne = info?.allInOne ?: false,

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/mapper/RoomInfoMapper.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/mapper/RoomInfoMapper.kt
@@ -27,7 +27,7 @@ fun RoomInfoResponseDto.toUiState(): RoomInfoUiState {
         area = r.area,
         floorSpace = r.floorSpace,
         roomType = r.roomType,
-        //roomComment = r.roomComment,
+        roomComment = r.roomComment.orEmpty(),
         department = r.department,
         departmentNumber = r.departmentNumber,
 

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/mapper/RoomInfoMapper.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/mapper/RoomInfoMapper.kt
@@ -46,6 +46,9 @@ fun RoomInfoResponseDto.toUiState(): RoomInfoUiState {
         wheelchairTable = info?.wheelchairTable ?: false,
         computerTable = info?.computerTable ?: false,
         frontDoor = info?.frontDoor ?: false,
-        backDoor = info?.backDoor ?: false
+        backDoor = info?.backDoor ?: false,
+
+        //roomInfo null 여부
+        hasRoomInfo = (info != null)
     )
 }

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/viewmodel/RoomInfoUiState.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/viewmodel/RoomInfoUiState.kt
@@ -33,4 +33,7 @@ data class RoomInfoUiState(
     //문 정보 (Door)
     val frontDoor: Boolean = false,
     val backDoor: Boolean = false,
+
+    //API RoomInfo null 여부
+    val hasRoomInfo: Boolean = true
 )

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/viewmodel/RoomInfoUiState.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/viewmodel/RoomInfoUiState.kt
@@ -1,5 +1,7 @@
 package com.ganaljigi.kubf.ui.roominfo.viewmodel
 
+import org.w3c.dom.Comment
+
 data class RoomInfoUiState(
     //상태 공통
     val isLoading: Boolean = false,
@@ -13,6 +15,7 @@ data class RoomInfoUiState(
     val lecture: Boolean = false,
     val capacity: Int = 0,
     val area: Double = 0.0,
+    val roomComment: String = "",
     val floorSpace: Double = 0.0,
     val roomType: String = "",
     val department: String = "",

--- a/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/viewmodel/RoomInfoViewModel.kt
+++ b/app/src/main/java/com/ganaljigi/kubf/ui/roominfo/viewmodel/RoomInfoViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.ganaljigi.kubf.ui.roominfo.repository.RoomInfoRepository
 import com.ganaljigi.kubf.ui.roominfo.mapper.toUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -33,24 +35,65 @@ class RoomInfoViewModel @Inject constructor(
     fun loadRoomInfo(
         buildingId: Long = savedStateHandle.get<Long>("buildingId") ?: -1L,
         spaceId: Long = savedStateHandle.get<Long>("spaceId") ?: -1L,
-        type: Int = savedStateHandle.get<Int>("type") ?: 1,
+        type: Int? = savedStateHandle.get<Int>("type") /*?: 1*/,
         buildingNameArg: String? = savedStateHandle.get<String>("buildingName")
     ) {
         if (buildingId <= 0 || spaceId <= 0) return
+
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            repository.getRoomInfo(buildingId, spaceId, type).fold(
-                onSuccess = { dto ->
-                    val mapped = dto.toUiState()
-                    _uiState.value = mapped.copy(
-                        isLoading = false,
-                        buildingName = buildingNameArg ?: mapped.buildingName
-                    )
-                },
-                onFailure = { e ->
-                    _uiState.update { it.copy(isLoading = false, error = e.message ?: "오류") }
-                }
-            )
+
+            if (type != null) {
+                repository.getRoomInfo(buildingId, spaceId, type).fold(
+                    onSuccess = { dto ->
+                        val mapped = dto.toUiState()
+                        _uiState.value = mapped.copy(
+                            isLoading = false,
+                            buildingName = buildingNameArg ?: mapped.buildingName
+                        )
+                    },
+                    onFailure = { e ->
+                        _uiState.update { it.copy(isLoading = false, error = e.message ?: "오류") }
+                    }
+                )
+            } else {
+                runCatching {
+                    coroutineScope {
+                        val r1 = async { repository.getRoomInfo(buildingId, spaceId, 1) }
+                        val r0 = async { repository.getRoomInfo(buildingId, spaceId, 0) }
+                        r1.await() to r0.await()
+                    }
+                }.fold(
+                    onSuccess = { (res1, res0) ->
+                        val mapped1 = res1.getOrNull()?.toUiState()
+                        val mapped0 = res0.getOrNull()?.toUiState()
+
+                        if (mapped1 == null && mapped0 == null) {
+                            _uiState.update { it.copy(isLoading = false, error = "데이터 없음") }
+                            return@fold
+                        }
+
+                        val base = mapped1 ?: mapped0!!
+                        val other = mapped0 ?: mapped1
+
+                        val merged = base.copy(
+                            roomPicUrls = (base.roomPicUrls + (other?.roomPicUrls ?: emptyList())).distinct(),
+                            roomName = base.roomName ?: other?.roomName,
+                            department = base.department.ifBlank { other?.department ?: "" },
+                            departmentNumber = base.departmentNumber.ifBlank { other?.departmentNumber ?: "" },
+                            roomType = base.roomType.ifBlank { other?.roomType ?: "" }
+                        )
+
+                        _uiState.value = merged.copy(
+                            isLoading = false,
+                            buildingName = buildingNameArg ?: merged.buildingName
+                        )
+                    },
+                    onFailure = { e ->
+                        _uiState.update { it.copy(isLoading = false, error = e.message ?: "오류") }
+                    }
+                )
+            }
         }
     }
     fun retry() = loadRoomInfo()

--- a/app/src/main/res/drawable/ic_roominfo_picviewer.xml
+++ b/app/src/main/res/drawable/ic_roominfo_picviewer.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M4.929,4.929C5.222,4.636 5.697,4.636 5.99,4.929L12,10.939L18.01,4.929C18.303,4.636 18.778,4.636 19.071,4.929C19.364,5.222 19.364,5.697 19.071,5.99L13.061,12L19.071,18.01C19.364,18.303 19.364,18.778 19.071,19.071C18.778,19.364 18.303,19.364 18.01,19.071L12,13.061L5.99,19.071C5.697,19.364 5.222,19.364 4.929,19.071C4.636,18.778 4.636,18.303 4.929,18.01L10.939,12L4.929,5.99C4.636,5.697 4.636,5.222 4.929,4.929Z"
+        android:fillColor="#999999"/>
+  </group>
+</vector>


### PR DESCRIPTION
## 🚀 이슈번호

## ✏️ 변경사항

-roominfo == null일 때 책상/의자/문 정보 카드 비노출
-사진: ROOM 외 DOOR 등 모든 타입 노출(층별 리스트는 ROOM만 유지)
-사진 터치 시 확대
-특이사항 표시
-강의실 태그 노출 수정
-호실 형태 팝업 수정


## 📷 스크린샷

-강의실 태그 노출 수정
수정 전:
<img width="1080" height="1262" alt="image" src="https://github.com/user-attachments/assets/c2fd856c-0bc3-4778-9a40-b3c833e077c6" />
수정 후:
<img width="493" height="542" alt="image" src="https://github.com/user-attachments/assets/7d70bced-c88e-42f6-bcd6-ae23df939d09" />

-사진 터치 시 확대
<video controls src="https://github.com/user-attachments/assets/f00cfd36-662d-4d29-82a9-912771b4b34b" width="640"></video>


-호실 형태 팝업 수정
수정 전: 
<img width="379" height="191" alt="image" src="https://github.com/user-attachments/assets/e71ea65e-f86f-43dc-a04b-e416c143f4f5" />
수정 후:
<img width="333" height="169" alt="image" src="https://github.com/user-attachments/assets/834944b1-65f6-469a-903b-65dad29a57ee" />


## ✍️ 사용법



## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 방 정보 페이지에 방 설명 필드가 추가되었습니다.
  * 방 사진 뷰어에 확대/축소 및 드래그 기능이 추가되었습니다.
  * 사진 뷰어에 현재/전체 사진 수를 표시하는 페이지 카운터가 추가되었습니다.

* **개선**
  * 방 정보의 UI 레이아웃이 개선되었습니다.
  * 방 사진 정렬 순서가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->